### PR TITLE
Update svelte.config.js | trailingSlash "ignore" test run

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,7 +10,7 @@ export default {
 			fallback: undefined,
 			precompress: false,
 			strict: true,
-			trailingSlash: 'always'
+			trailingSlash: 'ignore'
 		})
 	}
 };


### PR DESCRIPTION
Attempting to resolve URL link breaks when linking directly to Dashboard pages and/or opening links to pages in new tabs.